### PR TITLE
ci: tune CI matrix and fix release artifact collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,38 @@ on:
   pull_request:
     branches: [ "main", "master" ]
 
+# Least-privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Formatting and lints are platform-independent — run them once on Linux
+  # instead of repeating across the test matrix.
+  lint:
+    name: Lint (fmt + clippy)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Cache cargo registry
+      uses: Swatinem/rust-cache@v2
+
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+    - name: Run Clippy
+      run: cargo clippy --workspace --all-targets --all-features --exclude rustforge-python -- -D warnings
+
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -19,19 +50,11 @@ jobs:
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
 
     - name: Cache cargo registry
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "v2-arm64-fix"
-
-    - name: Check formatting
-      run: cargo fmt --all -- --check
-
-    - name: Run Clippy
-      run: cargo clippy --workspace --all-targets --all-features --exclude rustforge-python -- -D warnings
 
     - name: Run tests
       run: cargo test --workspace --all-features --exclude rustforge-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,23 @@ permissions:
 
 jobs:
   build-and-release:
-    name: Build and Release
+    name: Build and Release (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't cancel the other platforms if one fails — avoids a partial release.
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: rustforge-cli-linux-x86_64
+            bin: target/release/rustforge-cli
+          - os: macos-latest
+            # macos-latest runners are arm64 (macos-14+).
+            artifact: rustforge-cli-macos-arm64
+            bin: target/release/rustforge-cli
+          - os: windows-latest
+            artifact: rustforge-cli-windows-x86_64.exe
+            bin: target/release/rustforge-cli.exe
 
     steps:
     - uses: actions/checkout@v5
@@ -22,12 +34,19 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Build release
-      run: cargo build --release
+    - name: Cache cargo registry
+      uses: Swatinem/rust-cache@v2
 
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
+    - name: Build CLI (release)
+      run: cargo build --release -p rustforge-cli --bin rustforge-cli
+
+    # Give each platform's binary a distinct, descriptive name so the three
+    # matrix jobs don't overwrite each other's asset on the release.
+    - name: Rename artifact
+      shell: bash
+      run: cp "${{ matrix.bin }}" "${{ matrix.artifact }}"
+
+    - name: Create / update release
+      uses: softprops/action-gh-release@v2
       with:
-        files: |
-          target/release/rustforge-cli
-          target/release/rustforge-cli.exe
+        files: ${{ matrix.artifact }}


### PR DESCRIPTION
CI (ci.yml):
- Run fmt + clippy once in a dedicated `lint` job instead of repeating across the OS matrix; the test matrix now runs only `cargo test`.
- Add a concurrency group with cancel-in-progress to drop superseded runs.
- Add top-level `permissions: contents: read` (least privilege).

Release (release.yml):
- Name artifacts per platform (linux-x86_64 / macos-arm64 / windows-x86_64) so the Linux and macOS binaries no longer overwrite each other on the release.
- Upgrade softprops/action-gh-release v1 -> v2 (v1 runs on deprecated Node 16).
- fail-fast: false so one platform failing cannot cancel the others' uploads.
- Build only `-p rustforge-cli` and cache with Swatinem/rust-cache.