### PR TITLE
feat(dashboard): one-command --train launch + auto-open browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1767,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +368,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -587,10 +630,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -626,6 +772,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +860,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -761,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +1004,31 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -857,6 +1100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1107,6 +1359,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustforge-autograd"
 version = "0.1.0"
 dependencies = [
@@ -1144,6 +1405,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
+ "webbrowser",
 ]
 
 [[package]]
@@ -1235,6 +1497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1595,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1631,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1367,6 +1660,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -1393,7 +1697,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1408,10 +1721,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tokio"
@@ -1525,7 +1859,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -1560,10 +1894,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1584,6 +1936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1608,6 +1970,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1642,6 +2049,41 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1748,6 +2190,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +2232,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rustforge-dashboard/Cargo.toml
+++ b/crates/rustforge-dashboard/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+webbrowser = "1"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/rustforge-dashboard/Cargo.toml
+++ b/crates/rustforge-dashboard/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 axum = { version = "0.7", features = ["ws"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }
 serde = { workspace = true }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/rustforge-dashboard/README.md
+++ b/crates/rustforge-dashboard/README.md
@@ -8,15 +8,18 @@ dashboard only reads the CSV it already writes.
 ## Run
 
 ```bash
-# produce a (growing) CSV, e.g. via the CLI (algo is positional; CSV path is --output):
-cargo run -p rustforge-cli --release -- train dqn --env cartpole --episodes 200 --output target/run.csv
+# one command: train, serve, and open the browser
+cargo run -p rustforge-dashboard -- --train dqn --episodes 200
 
-# watch it live:
+# or just watch a CSV (default: target/cli_train_dqn.csv) — browser opens automatically
+cargo run -p rustforge-dashboard
 cargo run -p rustforge-dashboard -- --log target/run.csv
-# open http://127.0.0.1:8080
+
+# watch a run produced by the CLI directly (algo positional; CSV path is --output):
+cargo run -p rustforge-cli --release -- train dqn --env cartpole --episodes 200 --output target/run.csv
 ```
 
-Flags: `--log <PATH>` (required), `--port` (default 8080), `--host` (default 127.0.0.1).
+Flags: `--train [<ALGO>]` (spawn the trainer first; bare `--train` ⇒ `dqn`), `--episodes` (default 200), `--env` (default `cartpole`), `--log <PATH>` (default `target/cli_train_dqn.csv`), `--no-open` (don't open a browser), `--port` (default 8080), `--host` (default 127.0.0.1).
 
 ## How it works
 

--- a/crates/rustforge-dashboard/src/launch.rs
+++ b/crates/rustforge-dashboard/src/launch.rs
@@ -1,0 +1,167 @@
+//! Helpers for the one-command launch: building the trainer subprocess
+//! invocation and computing the browser URL. The pure functions are
+//! unit-tested; the side-effecting spawn/open wrappers are exercised by the
+//! CLI wiring and manual verification.
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+use clap::ValueEnum;
+
+/// RL algorithm to train. Mirrors `rustforge-cli`'s positional algo; forwarded
+/// as a string so the dashboard stays decoupled from the training crates.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Algo {
+    Dqn,
+}
+
+impl Algo {
+    /// The token the CLI's `train` subcommand expects as its positional algo.
+    pub fn as_arg(self) -> &'static str {
+        match self {
+            Algo::Dqn => "dqn",
+        }
+    }
+}
+
+/// Environment to train on. Mirrors `rustforge-cli`'s `--env`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Env {
+    Cartpole,
+    Gridworld,
+}
+
+impl Env {
+    pub fn as_arg(self) -> &'static str {
+        match self {
+            Env::Cartpole => "cartpole",
+            Env::Gridworld => "gridworld",
+        }
+    }
+}
+
+/// Build the argument vector for `rustforge-cli` (after the program and any
+/// leading `run -p …` args): `train <algo> --env <env> --episodes <N> --output <log>`.
+pub fn train_child_args(algo: Algo, env: Env, episodes: usize, log: &Path) -> Vec<String> {
+    vec![
+        "train".to_string(),
+        algo.as_arg().to_string(),
+        "--env".to_string(),
+        env.as_arg().to_string(),
+        "--episodes".to_string(),
+        episodes.to_string(),
+        "--output".to_string(),
+        log.to_string_lossy().into_owned(),
+    ]
+}
+
+/// Compute the URL to open in a browser. A wildcard bind address
+/// (`0.0.0.0`, `::`, or empty) is not connectable, so fall back to loopback.
+pub fn browser_url(host: &str, port: u16) -> String {
+    let connect_host = match host {
+        "0.0.0.0" | "::" | "" => "127.0.0.1",
+        h => h,
+    };
+    format!("http://{connect_host}:{port}")
+}
+
+/// Resolve how to launch the trainer: prefer a `rustforge-cli` binary sitting
+/// next to this executable; otherwise fall back to `cargo run -p rustforge-cli --`
+/// (reliable in a dev checkout — cargo builds the CLI as needed). Returns the
+/// program to run and the leading args that precede the `train …` args.
+pub fn resolve_trainer() -> (String, Vec<String>) {
+    let exe_name = if cfg!(windows) {
+        "rustforge-cli.exe"
+    } else {
+        "rustforge-cli"
+    };
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let sibling = dir.join(exe_name);
+            if sibling.is_file() {
+                return (sibling.to_string_lossy().into_owned(), Vec::new());
+            }
+        }
+    }
+    (
+        "cargo".to_string(),
+        vec![
+            "run".to_string(),
+            "-p".to_string(),
+            "rustforge-cli".to_string(),
+            "--".to_string(),
+        ],
+    )
+}
+
+/// Spawn the trainer as a child process, inheriting stdio so its progress is
+/// visible in the same terminal. Returns the child handle so the caller can
+/// kill it on shutdown.
+pub fn spawn_trainer(algo: Algo, env: Env, episodes: usize, log: &Path) -> std::io::Result<Child> {
+    let (program, mut args) = resolve_trainer();
+    args.extend(train_child_args(algo, env, episodes, log));
+    Command::new(program)
+        .args(args)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+}
+
+/// Open `url` in the default browser. Failure is non-fatal — warn and continue.
+pub fn open_browser(url: &str) {
+    if let Err(e) = webbrowser::open(url) {
+        eprintln!("warning: could not open a browser ({e}); open {url} manually");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn train_args_for_dqn_cartpole() {
+        let args = train_child_args(
+            Algo::Dqn,
+            Env::Cartpole,
+            200,
+            &PathBuf::from("target/run.csv"),
+        );
+        let expected: Vec<&str> = vec![
+            "train",
+            "dqn",
+            "--env",
+            "cartpole",
+            "--episodes",
+            "200",
+            "--output",
+            "target/run.csv",
+        ];
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn train_args_forward_env_and_episodes() {
+        let args = train_child_args(Algo::Dqn, Env::Gridworld, 50, &PathBuf::from("a.csv"));
+        assert_eq!(args[1], "dqn");
+        assert_eq!(args[3], "gridworld");
+        assert_eq!(args[5], "50");
+        assert_eq!(args.last().unwrap(), "a.csv");
+    }
+
+    #[test]
+    fn browser_url_loopback_passthrough() {
+        assert_eq!(browser_url("127.0.0.1", 8080), "http://127.0.0.1:8080");
+    }
+
+    #[test]
+    fn browser_url_wildcard_maps_to_loopback() {
+        assert_eq!(browser_url("0.0.0.0", 8080), "http://127.0.0.1:8080");
+        assert_eq!(browser_url("::", 9000), "http://127.0.0.1:9000");
+        assert_eq!(browser_url("", 3000), "http://127.0.0.1:3000");
+    }
+
+    #[test]
+    fn browser_url_custom_host_passthrough() {
+        assert_eq!(browser_url("192.168.1.5", 8080), "http://192.168.1.5:8080");
+    }
+}

--- a/crates/rustforge-dashboard/src/lib.rs
+++ b/crates/rustforge-dashboard/src/lib.rs
@@ -1,4 +1,5 @@
 //! RustForge training dashboard: tail a training CSV and stream it to a browser.
+pub mod launch;
 pub mod metrics;
 pub mod server;
 pub mod state;

--- a/crates/rustforge-dashboard/src/main.rs
+++ b/crates/rustforge-dashboard/src/main.rs
@@ -1,8 +1,12 @@
 //! `rustforge-dashboard` — live web dashboard for a RustForge training CSV.
+//!
+//! Watch an existing run, or with `--train` start one and watch it in a single
+//! command. Auto-opens the browser unless `--no-open` is given.
 use std::path::PathBuf;
 
 use clap::Parser;
 
+use rustforge_dashboard::launch::{browser_url, open_browser, spawn_trainer, Algo, Env};
 use rustforge_dashboard::server::router;
 use rustforge_dashboard::state::{spawn_tail_task, AppState};
 
@@ -12,9 +16,21 @@ use rustforge_dashboard::state::{spawn_tail_task, AppState};
     about = "Live web dashboard for RustForge training runs"
 )]
 struct Args {
-    /// Path to the training CSV log (episode,reward,avg_loss,epsilon,global_step).
-    #[arg(long)]
+    /// Training CSV to watch (also the trainer's --output in --train mode).
+    #[arg(long, default_value = "target/cli_train_dqn.csv")]
     log: PathBuf,
+    /// Train first, then watch: spawn `rustforge-cli train <ALGO>`. Bare `--train` => dqn.
+    #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "dqn")]
+    train: Option<Algo>,
+    /// Episodes to train (only used with --train).
+    #[arg(long, default_value_t = 200)]
+    episodes: usize,
+    /// Environment to train on (only used with --train).
+    #[arg(long, value_enum, default_value = "cartpole")]
+    env: Env,
+    /// Do not auto-open the browser on startup.
+    #[arg(long)]
+    no_open: bool,
     /// Port to serve on.
     #[arg(long, default_value_t = 8080)]
     port: u16,
@@ -26,6 +42,24 @@ struct Args {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+
+    // Optionally spawn the trainer (writing to the same CSV we watch) before serving.
+    let mut trainer = match args.train {
+        Some(algo) => {
+            println!(
+                "Starting trainer: {} on {} for {} episodes -> {}",
+                algo.as_arg(),
+                args.env.as_arg(),
+                args.episodes,
+                args.log.display()
+            );
+            Some(
+                spawn_trainer(algo, args.env, args.episodes, &args.log)
+                    .map_err(|e| anyhow::anyhow!("failed to start trainer (rustforge-cli): {e}"))?,
+            )
+        }
+        None => None,
+    };
 
     let state = AppState::new(1024);
     spawn_tail_task(state.clone(), args.log.clone());
@@ -39,6 +73,20 @@ async fn main() -> anyhow::Result<()> {
         args.log.display()
     );
 
-    axum::serve(listener, router(state)).await?;
+    if !args.no_open {
+        open_browser(&browser_url(&args.host, args.port));
+    }
+
+    // Serve until Ctrl+C; then reap the trainer if it is still running.
+    let shutdown = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    axum::serve(listener, router(state))
+        .with_graceful_shutdown(shutdown)
+        .await?;
+
+    if let Some(child) = trainer.as_mut() {
+        let _ = child.kill(); // already-exited child -> Err, which we ignore
+    }
     Ok(())
 }

--- a/crates/rustforge-dashboard/src/main.rs
+++ b/crates/rustforge-dashboard/src/main.rs
@@ -43,7 +43,21 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // Optionally spawn the trainer (writing to the same CSV we watch) before serving.
+    let state = AppState::new(1024);
+    spawn_tail_task(state.clone(), args.log.clone());
+
+    // Bind FIRST: a bind failure (e.g. port already in use) must error out
+    // BEFORE we spawn a trainer that would otherwise be orphaned.
+    let addr = format!("{}:{}", args.host, args.port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
+    println!(
+        "RustForge dashboard: http://{addr}  (watching {})",
+        args.log.display()
+    );
+
+    // Port is secured — now optionally spawn the trainer.
     let mut trainer = match args.train {
         Some(algo) => {
             println!(
@@ -61,32 +75,20 @@ async fn main() -> anyhow::Result<()> {
         None => None,
     };
 
-    let state = AppState::new(1024);
-    spawn_tail_task(state.clone(), args.log.clone());
-
-    let addr = format!("{}:{}", args.host, args.port);
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
-    println!(
-        "RustForge dashboard: http://{addr}  (watching {})",
-        args.log.display()
-    );
-
     if !args.no_open {
         open_browser(&browser_url(&args.host, args.port));
     }
 
-    // Serve until Ctrl+C; then reap the trainer if it is still running.
+    // Serve until Ctrl+C; reap the trainer on EVERY exit path (success or error).
     let shutdown = async {
         let _ = tokio::signal::ctrl_c().await;
     };
-    axum::serve(listener, router(state))
+    let serve_result = axum::serve(listener, router(state))
         .with_graceful_shutdown(shutdown)
-        .await?;
-
+        .await;
     if let Some(child) = trainer.as_mut() {
-        let _ = child.kill(); // already-exited child -> Err, which we ignore
+        let _ = child.kill();
     }
+    serve_result?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds a one-command launch mode to `rustforge-dashboard` so you don't need two terminals + a manual browser tab.

```bash
# one command: train, serve, and open the browser
cargo run -p rustforge-dashboard -- --train dqn --episodes 200

# or just watch a CSV (default: target/cli_train_dqn.csv) — browser opens automatically
cargo run -p rustforge-dashboard
```

## What changed

- New `src/launch.rs`: `Algo`/`Env` (`clap::ValueEnum`, mirrored from the CLI and forwarded as **strings** — the dashboard keeps **no** Cargo dependency on the RL crates), pure unit-tested `train_child_args` + `browser_url`, and `resolve_trainer`/`spawn_trainer`/`open_browser`.
- `src/main.rs` rewired: default `--log` (`target/cli_train_dqn.csv`, == the CLI's `--output` default), `--train [<ALGO>]` (spawns `rustforge-cli train …` as a child writing the watched CSV), `--episodes`, `--env`, `--no-open`. Binds the listener **before** spawning the trainer (so a port conflict can't orphan a child), auto-opens the browser unless `--no-open`, and reaps the trainer on every graceful-shutdown exit path.
- New dep: `webbrowser` (cross-platform browser open). Enables tokio's `signal` feature for Ctrl+C.

## Testing

- 19 crate tests (14 prior + 5 new unit tests: `train_child_args` arg vector, `browser_url` wildcard→loopback). `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.
- Live end-to-end: `--train dqn --episodes 60` spawned training, the watched CSV grew, the server served, and a browser tab opened automatically to the live charts.

## Notes

- Decoupling intact: training is orchestrated by shelling out to the `rustforge-cli` binary (sibling binary, else `cargo run -p rustforge-cli`).
- Known limitation: a hard OS kill (SIGKILL) of the dashboard — rather than Ctrl+C — can orphan the trainer child; the normal Ctrl+C path reaps it.
