### PR TITLE
feat(dashboard): full-width themed redesign with dark/light toggle

### DIFF
--- a/crates/rustforge-dashboard/static/app.js
+++ b/crates/rustforge-dashboard/static/app.js
@@ -3,18 +3,55 @@
 const MAX_POINTS = 2000;   // render cap per chart
 const ROLL_WINDOW = 100;   // rolling-average window (episodes)
 
+// Series colors are theme-independent (chosen to read on both surfaces). Area
+// fills use an 8-digit hex at ~20% alpha (color + "33"), which looks right over
+// both the dark (#161b22) and light (#ffffff) surfaces — no per-theme fill logic.
+const COLOR = { reward: "#f97316", avg: "#3b82f6", loss: "#a855f7", epsilon: "#22c55e" };
+
+// Per-theme chart "chrome" (gridlines + axis ticks + legend text). Series colors
+// above stay fixed across themes; only these change.
+const THEME = {
+  dark: { grid: "#2b3340", tick: "#8b949e" },
+  light: { grid: "#e4e8ee", tick: "#5b6573" },
+};
+
 // Full series kept in memory; charts render a downsampled view.
 const data = { episode: [], reward: [], loss: [], epsilon: [] };
+
+// Shared chart options so all three charts share the same chrome (colored by
+// applyChartTheme). maintainAspectRatio:false makes the chart fill its
+// fixed-height wrapper instead of imposing its own aspect ratio.
+function baseOptions(showLegend) {
+  return {
+    animation: false,
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { title: { display: true, text: "episode" }, grid: {}, ticks: {} },
+      y: { grid: {}, ticks: {} },
+    },
+    plugins: { legend: { display: showLegend, labels: {} } },
+  };
+}
 
 function makeChart(id, label, color) {
   return new Chart(document.getElementById(id).getContext("2d"), {
     type: "line",
-    data: { labels: [], datasets: [{ label, data: [], borderColor: color, pointRadius: 0, borderWidth: 1.5 }] },
-    options: {
-      animation: false,
-      scales: { x: { title: { display: true, text: "episode" } } },
-      plugins: { legend: { display: true } },
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label,
+          data: [],
+          borderColor: color,
+          backgroundColor: color + "33",
+          fill: true,
+          pointRadius: 0,
+          borderWidth: 1.6,
+        },
+      ],
     },
+    options: baseOptions(false),
   });
 }
 
@@ -23,14 +60,45 @@ const rewardChart = new Chart(document.getElementById("chart-reward").getContext
   data: {
     labels: [],
     datasets: [
-      { label: "reward", data: [], borderColor: "#1565c0", pointRadius: 0, borderWidth: 1 },
-      { label: "rolling avg (100)", data: [], borderColor: "#d84315", pointRadius: 0, borderWidth: 2 },
+      {
+        label: "reward",
+        data: [],
+        borderColor: COLOR.reward,
+        backgroundColor: COLOR.reward + "33",
+        fill: true,
+        pointRadius: 0,
+        borderWidth: 1.4,
+      },
+      {
+        label: "rolling avg (100)",
+        data: [],
+        borderColor: COLOR.avg,
+        fill: false,
+        pointRadius: 0,
+        borderWidth: 2.4,
+      },
     ],
   },
-  options: { animation: false, scales: { x: { title: { display: true, text: "episode" } } } },
+  options: baseOptions(true),
 });
-const lossChart = makeChart("chart-loss", "avg_loss", "#6a1b9a");
-const epsilonChart = makeChart("chart-epsilon", "epsilon", "#2e7d32");
+const lossChart = makeChart("chart-loss", "avg_loss", COLOR.loss);
+const epsilonChart = makeChart("chart-epsilon", "epsilon", COLOR.epsilon);
+const allCharts = [rewardChart, lossChart, epsilonChart];
+
+// Re-theme already-instantiated charts. Chart.defaults.color only affects FUTURE
+// charts, so reassign each live instance's chrome colors, then update.
+function applyChartTheme(theme) {
+  const c = THEME[theme] || THEME.dark;
+  for (const chart of allCharts) {
+    chart.options.scales.x.grid.color = c.grid;
+    chart.options.scales.y.grid.color = c.grid;
+    chart.options.scales.x.ticks.color = c.tick;
+    chart.options.scales.y.ticks.color = c.tick;
+    chart.options.scales.x.title.color = c.tick;
+    chart.options.plugins.legend.labels.color = c.tick;
+    chart.update("none");
+  }
+}
 
 // Downsample y[] to <= MAX_POINTS, preserving per-bucket min & max so spikes/
 // crashes are never smoothed away. Returns parallel {labels, values}.
@@ -136,4 +204,21 @@ function connect() {
   };
 }
 
+// Theme toggle: flip <html data-theme>, persist, re-theme the charts.
+function currentTheme() {
+  return document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
+}
+function setTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  try { localStorage.setItem("rf-theme", theme); } catch (e) { /* private mode: keep session theme */ }
+  applyChartTheme(theme);
+}
+const toggleBtn = document.getElementById("theme-toggle");
+if (toggleBtn) {
+  toggleBtn.addEventListener("click", () => {
+    setTheme(currentTheme() === "dark" ? "light" : "dark");
+  });
+}
+
+applyChartTheme(currentTheme());
 connect();

--- a/crates/rustforge-dashboard/static/index.html
+++ b/crates/rustforge-dashboard/static/index.html
@@ -2,28 +2,52 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>RustForge Dashboard</title>
   <link rel="stylesheet" href="/static/style.css" />
+  <script>
+    // Apply the saved theme before first paint to avoid a flash of the wrong theme.
+    try {
+      var t = localStorage.getItem("rf-theme") || "dark";
+      document.documentElement.setAttribute("data-theme", t);
+    } catch (e) {
+      document.documentElement.setAttribute("data-theme", "dark");
+    }
+  </script>
 </head>
 <body>
-  <header>
-    <h1>🔥 RustForge Dashboard</h1>
-    <span id="status" class="pill waiting">waiting for data</span>
-  </header>
+  <div class="wrap">
+    <header>
+      <div class="brand"><span class="flame">🔥</span> RustForge Dashboard</div>
+      <div class="hdr-right">
+        <span id="status" class="pill waiting">waiting for data</span>
+        <button id="theme-toggle" class="toggle" type="button" aria-label="Toggle dark or light theme">◐ Theme</button>
+      </div>
+    </header>
 
-  <section id="cards">
-    <div class="card"><div class="label">Episode</div><div id="stat-episode" class="value">–</div></div>
-    <div class="card"><div class="label">Reward</div><div id="stat-reward" class="value">–</div></div>
-    <div class="card"><div class="label">Best reward</div><div id="stat-best" class="value">–</div></div>
-    <div class="card"><div class="label">Rolling avg (100)</div><div id="stat-avg" class="value">–</div></div>
-    <div class="card"><div class="label">Env steps</div><div id="stat-steps" class="value">–</div></div>
-  </section>
+    <section id="cards">
+      <div class="card"><div class="label">Episode</div><div id="stat-episode" class="value">–</div></div>
+      <div class="card"><div class="label">Reward</div><div id="stat-reward" class="value">–</div></div>
+      <div class="card best"><div class="label">Best reward</div><div id="stat-best" class="value">–</div></div>
+      <div class="card"><div class="label">Rolling avg (100)</div><div id="stat-avg" class="value">–</div></div>
+      <div class="card"><div class="label">Env steps</div><div id="stat-steps" class="value">–</div></div>
+    </section>
 
-  <section class="charts">
-    <canvas id="chart-reward"></canvas>
-    <canvas id="chart-loss"></canvas>
-    <canvas id="chart-epsilon"></canvas>
-  </section>
+    <section class="charts">
+      <div class="chart-card hero">
+        <h2>Reward</h2>
+        <div class="canvas-wrap"><canvas id="chart-reward"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Loss</h2>
+        <div class="canvas-wrap"><canvas id="chart-loss"></canvas></div>
+      </div>
+      <div class="chart-card">
+        <h2>Epsilon</h2>
+        <div class="canvas-wrap"><canvas id="chart-epsilon"></canvas></div>
+      </div>
+    </section>
+  </div>
 
   <script src="/static/chart.min.js"></script>
   <script src="/static/app.js"></script>

--- a/crates/rustforge-dashboard/static/style.css
+++ b/crates/rustforge-dashboard/static/style.css
@@ -1,13 +1,70 @@
-body { font-family: system-ui, sans-serif; margin: 1.5rem; color: #1a1a1a; }
-header { display: flex; align-items: center; gap: 1rem; }
-h1 { font-size: 1.4rem; margin: 0; }
-.pill { font-size: .8rem; padding: .2rem .6rem; border-radius: 999px; color: #fff; }
-.pill.waiting { background: #888; }
-.pill.live { background: #2e7d32; }
-.pill.disconnected { background: #c62828; }
-#cards { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1.2rem 0; }
-.card { border: 1px solid #ddd; border-radius: 8px; padding: .7rem 1rem; min-width: 8rem; }
-.card .label { font-size: .75rem; color: #666; }
-.card .value { font-size: 1.3rem; font-weight: 600; }
-.charts { display: grid; gap: 1.5rem; max-width: 900px; }
-canvas { border: 1px solid #eee; border-radius: 8px; padding: .5rem; }
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --border: #2b3340;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #f97316;
+  --pill-waiting: #6b7280;
+  --pill-live: #22c55e;
+  --pill-disc: #ef4444;
+}
+:root[data-theme="light"] {
+  --bg: #f6f8fa;
+  --surface: #ffffff;
+  --border: #e4e8ee;
+  --text: #1f2328;
+  --muted: #5b6573;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 1400px; margin: 0 auto; padding: 1.5rem 1.75rem 2.5rem; }
+header { display: flex; align-items: center; gap: 1rem; margin-bottom: 1.4rem; }
+.brand { font-size: 1.35rem; font-weight: 600; display: flex; align-items: center; gap: .55rem; }
+.hdr-right { margin-left: auto; display: flex; align-items: center; gap: .75rem; }
+.pill {
+  font-size: .78rem; font-weight: 500; padding: .3rem .7rem; border-radius: 999px;
+  color: #fff; display: inline-flex; align-items: center; gap: .4rem;
+}
+.pill::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: currentColor; opacity: .9; }
+.pill.waiting { background: var(--pill-waiting); }
+.pill.live { background: var(--pill-live); }
+.pill.disconnected { background: var(--pill-disc); }
+.pill.live::before { background: #fff; animation: rf-pulse 1.4s ease-in-out infinite; }
+@keyframes rf-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }
+.toggle {
+  background: var(--surface); color: var(--text); border: 1px solid var(--border);
+  border-radius: 8px; padding: .35rem .7rem; font-size: .8rem; cursor: pointer;
+}
+.toggle:hover { border-color: var(--accent); }
+#cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px; margin-bottom: 1.4rem;
+}
+.card {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+  padding: .85rem 1.05rem; min-width: 0;
+}
+.card .label { font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.card .value { font-size: 1.5rem; font-weight: 600; margin-top: .25rem; }
+.card.best .value { color: var(--accent); }
+.charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.chart-card {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+  padding: .9rem 1.1rem 1.1rem; min-width: 0; min-height: 0;
+}
+.chart-card.hero { grid-column: 1 / -1; }
+.chart-card h2 { font-size: .92rem; font-weight: 500; color: var(--muted); margin: 0 0 .6rem; }
+.canvas-wrap { position: relative; height: 260px; min-width: 0; min-height: 0; }
+.chart-card.hero .canvas-wrap { height: 320px; }
+canvas { display: block; }
+@media (max-width: 720px) {
+  .charts { grid-template-columns: 1fr; }
+  .wrap { padding: 1.25rem 1rem 2rem; }
+}


### PR DESCRIPTION
## Summary

Visual redesign of the dashboard frontend — from a bare left-column layout into a polished, full-width, themed UI. Pure frontend change: no Rust code, no new dependencies, and the WebSocket protocol / data flow / downsampling logic are untouched.

## What changed (three embedded static files)

- **Full-width layout** — drops the old `max-width:900px` chart cap. A centered `max-width:1400px` container with a responsive grid: the **reward chart spans the top (hero)**, loss + epsilon sit side-by-side below, and all three stack on narrow screens.
- **Dark default + light/dark toggle** — a CSS-variable theme system (`:root` dark, `:root[data-theme="light"]` light). The choice persists in `localStorage` and is applied before first paint (no flash). A header toggle flips it and re-themes the charts live.
- **Refined cards + header** — uppercase muted labels with large values, the *Best reward* card accented; a header with the flame mark, an animated `live` pill, and the toggle.
- **Themed charts** — a coherent palette (reward orange, rolling-avg blue, loss violet, epsilon green) with soft 8-digit-hex area fills, subtle gridlines, and muted ticks instead of Chart.js defaults.

## Implementation notes

- Preserves every element ID the data layer drives (`status`, `stat-*`, `chart-*`) and the status-pill classes — the `/ws` handling, rolling average, min/max downsampling, and reconnect are byte-for-byte unchanged.
- Chart wrappers (and grid items) use `min-width:0; min-height:0` with a fixed-height canvas wrapper + `maintainAspectRatio:false`, avoiding the Chart.js-in-CSS-grid `ResizeObserver loop` / unbounded-growth trap.
- `applyChartTheme()` mutates each live chart instance's grid/tick/legend colors then `update('none')` (setting `Chart.defaults` alone only affects future charts). Series colors are theme-independent; only the chrome colors change.
- Stays self-contained: system font stack, no external fonts/CDN, assets still embedded via `include_str!`.

## Testing

- `cargo test -p rustforge-dashboard` green (the embedded-asset smoke test recompiles the new HTML/CSS/JS); `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.
- Manual: ran against a 180-episode demo CSV (NaN warmup + reward dips) — dark full-width layout renders, charts themed, the loss chart gaps the warmup, the dark/light toggle switches + re-themes + survives reload, no console errors.
